### PR TITLE
Update _version_npm to latest as of 2/25/21

### DIFF
--- a/lxc/nginx-proxy-manager/setup.sh
+++ b/lxc/nginx-proxy-manager/setup.sh
@@ -9,7 +9,7 @@ cd $_temp_dir
 
 . /etc/os-release
 _version_alpine=${VERSION_ID%.*}
-_version_npm=${_version_npm:-2.6.1}
+_version_npm=${_version_npm:-2.8.0}
 
 # add openresty repo
 if [ ! -f /etc/apk/keys/admin@openresty.com-5ea678a6.rsa.pub ]; then


### PR DESCRIPTION
Nginx Proxy Manager is now on version 2.8.0.