### PR TITLE
fix: increase yarn timeout for slow networks

### DIFF
--- a/lxc/nginx-proxy-manager/install/ubuntu.sh
+++ b/lxc/nginx-proxy-manager/install/ubuntu.sh
@@ -169,7 +169,7 @@ cp -r global/* /app/global
 log "Building frontend"
 cd ./frontend
 export NODE_ENV=development
-runcmd yarn install
+runcmd yarn install --network-timeout=30000
 runcmd yarn build
 cp -r dist/* /app/frontend
 cp -r app-images/* /app/frontend/images
@@ -194,7 +194,7 @@ EOF
 fi
 cd /app
 export NODE_ENV=development
-runcmd yarn install
+runcmd yarn install --network-timeout=30000
 
 # Create NPM service
 log "Creating NPM service"


### PR DESCRIPTION
On slower internet connections yarn will give the following message due to the request taking too long.
`There appears to be trouble with your network connection. Retrying`

Increasing the `network-timeout` should fix this.