### PR TITLE
wrong content in "/etc/envirnment" by installer

### DIFF
--- a/lxc/nginx-proxy-manager/install/debian.sh
+++ b/lxc/nginx-proxy-manager/install/debian.sh
@@ -78,7 +78,7 @@ log "Installing python"
 runcmd apt-get install -y -q --no-install-recommends python3 python3-distutils python3-venv
 python3 -m venv /opt/certbot/
 export PATH=/opt/certbot/bin:$PATH
-grep -qo "/opt/certbot" /etc/environment || echo "$PATH" > /etc/environment
+grep -qo "/opt/certbot" /etc/environment || echo "PATH=\"$PATH\"" > /etc/environment
 # Install certbot and python dependancies
 runcmd wget -qO - https://bootstrap.pypa.io/get-pip.py | python -
 if [ "$(getconf LONG_BIT)" = "32" ]; then


### PR DESCRIPTION
the file /etc/envirnment is just a path, but it looks like that

PATH="/bin"