### PR TITLE
update alpine os version to 3.16

### DIFF
--- a/lxc/nginx-proxy-manager/create.sh
+++ b/lxc/nginx-proxy-manager/create.sh
@@ -34,7 +34,7 @@ function error {
 _raw_base="https://raw.githubusercontent.com/ej52/proxmox-scripts/main/lxc/nginx-proxy-manager"
 # Operating system
 _os_type=alpine
-_os_version=3.12
+_os_version=3.16
 # System architecture
 _arch=$(dpkg --print-architecture)
 


### PR DESCRIPTION
Hi @ej52 

alpine 3.12 template is no more available with proxmox 7.2.
I updated the version to the newest version available (3.16) and successfully built it.

This PR update the alpine os version.

Thanks for the script btw !