### PR TITLE
fix: Only change version number of the package

### DIFF
--- a/apps/nginx-proxy-manager/install.sh
+++ b/apps/nginx-proxy-manager/install.sh
@@ -217,9 +217,9 @@ step_start "Nginx Proxy Manager" "Downloading" "Downloaded"
 
 step_start "Enviroment" "Setting up" "Setup"
   # Update NPM version in package.json files
-  sed -i "s+0.0.0+$NPM_VERSION+g" backend/package.json
-  sed -i "s+0.0.0+$NPM_VERSION+g" frontend/package.json
-
+  sed -i "s/\"version\": \"0.0.0\"/\"version\": \"$NPM_VERSION\"/" backend/package.json
+  sed -i "s/\"version\": \"0.0.0\"/\"version\": \"$NPM_VERSION\"/" frontend/package.json
+  
   # Fix nginx config files for use with openresty defaults
   sed -i 's/user npm/user root/g; s/^pid/#pid/g; s+^daemon+#daemon+g' docker/rootfs/etc/nginx/nginx.conf
   sed -i 's/include-system-site-packages = false/include-system-site-packages = true/g' /opt/certbot/pyvenv.cfg


### PR DESCRIPTION
This PR fixes prevents `"sass-loader": "^10.0.0"` being changed to `"^12.11.0"` resulting in the following installation error:

> **✘ Frontend not Built**
> error Couldn't find any versions for "sass-loader" that matches "^12.11.0"

It checks for the full pattern `"version": "0.0.0"` rather than any occurrence of `0.0.0`.